### PR TITLE
Readline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ r: 5
 
 ## CFG
 
-Input -> Expr `\n` | Comment `\n` | Expr Comment `\n`\
+Input -> Expr | Comment | Expr Comment\
 Comment -> `#` `any text`\
 Expr -> FunctionExpr | AssignmentExpr | AdditiveExpr\
 FunctionExpr -> `fn` ID `(` ParamExpr `)` `=` AdditiveExpr\

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ OBJS=$(patsubst %,$(OBJ)/%,$(_OBJS))
 all: $(OBJ) $(BIN)/mint
 $(BIN)/mint: $(OBJS)
 	mkdir -p $(BIN)
-	$(CC) -o $@ $^ $(LDFLAGS)
+	$(CC) -o $@ $^ $(LDFLAGS) -lreadline
 
 lexer_tests: $(OBJ) $(TEST_BIN) $(TEST_BIN)/lexer_tests
 parser_tests: $(OBJ) $(TEST_BIN) $(TEST_BIN)/parser_tests

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -131,7 +131,7 @@ static TokenList *tok(const char *input, unsigned int pos, unsigned int length) 
         t->token = TOK_EXP;
         t->next = tok(input, pos + 1, length);
         return t;
-    } else if (regexec(&comment_re, str, 2, &re_match, 0) == 0) {
+    } else if (regexec(&comment_re, str, 1, &re_match, 0) == 0) {
         int match_length = re_match.rm_eo - re_match.rm_so;
         t = malloc(sizeof(TokenList));
         t->token = TOK_COMMENT;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -7,7 +7,6 @@ typedef enum {
     TOK_COMMENT,
     TOK_DIV,
     TOK_DOT,
-    TOK_ENDLN,
     TOK_EQUAL,
     TOK_EXP,
     TOK_FLOAT,

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -30,6 +30,8 @@ typedef struct token {
 } TokenList;
 
 TokenList *tokenize(const char *input);
+void compile_regexs();
+void free_regexs();
 void free_token_list(TokenList *tok_l);
 void print_token_list(TokenList *tok_l);
 char *token_to_str(TokenList *tok_l);

--- a/src/main.c
+++ b/src/main.c
@@ -14,46 +14,85 @@
 #define PROMPT TEAL "mint" END_COLOR "|> "
 #define BUF_SIZE 1024
 
-static void process_cmd(char *cmd, Env_t *env);
+static char *process_input(char *input, Env_t *env);
+static char *aggregate_args(int argc, char **argv);
+static void process_file(FILE *file, Env_t *env);
+static void repl_loop(Env_t *env);
 
 int main(int argc, char **argv) {
     Env_t *env = init_env();
+    compile_regexs();
 
     /* determine invocation method */
     if (argc == 1) {
         if (isatty(0)) {
             repl_loop(env);
         } else {
+            /* input redirection */
             process_file(stdin, env);
         }
     } else if (argc > 1) {
+        char *expr, *result;
+
         /* process args as expr */
+        expr = aggregate_args(argc, argv);
+        result = process_input(expr, env);
+
+        if (result != NULL) {
+            printf("%s\n", result);
+        }
+
+        free(expr);
+        free(result);
     }
 
     free_env(env);
+    free_regexs();
     return 0;
 }
 
+static char *aggregate_args(int argc, char **argv) {
+    int i, expr_length = 0;
+    char *expr;
+
+    for (i = 1; i < argc; i++) {
+        expr_length += strlen(argv[i]) + 1; /* appending a space */
+    }
+
+    expr = malloc(expr_length + 1);
+
+    for (i = 1; i < argc; i++) {
+        strcat(expr, argv[i]);
+        strcat(expr, " ");
+    }
+
+    return expr;
+}
+
 static void process_file(FILE *file, Env_t *env) {
-    char line[BUF_SIZE] = {0};
+    char line[BUF_SIZE] = {0}, *result = NULL;
 
     while(fgets(line, BUF_SIZE, file)) {
-        char cmd[BUF_SIZE] = "";
+        free(result);
+        line[strlen(line) - 1] = '\0';
 
-        sscanf(line, "%s", cmd);
-
-        if (strcmp(cmd, "") == 0) {
+        if (strcmp(line, "") == 0) {
             continue;
         }
 
-        process_cmd(line, env);
+        result = process_input(line, env);
+    }
+    
+    if (result != NULL) {
+        printf("%s\n", result);
     }
 
+    free(result);
     fclose(file);
 }
 
 static void repl_loop(Env_t *env) {
-    char *line;
+    char *line, *result;
 
     while ((line = readline(PROMPT))) {
         if (strcmp(line, "") == 0) {
@@ -64,22 +103,28 @@ static void repl_loop(Env_t *env) {
             break;
         }
 
-        process_cmd(line, env);
+        result = process_input(line, env);
+
+        if (result != NULL) {
+            printf("%s\n", result);
+        }
+
         add_history(line);
+        free(result);
     }
 }
 
-static void process_cmd(char *cmd, Env_t *env) {
-    char *str;
+static char *process_input(char *input, Env_t *env) {
     TokenList *tok_l;
     ExprTree *tree;
+    char *result;
 
     errno = 0;
-    tok_l = tokenize(cmd);
+    tok_l = tokenize(input);
 
     if (errno != 0) {
         free_token_list(tok_l);
-        return;
+        return NULL;
     }
 
     tree = parse(tok_l);
@@ -87,7 +132,7 @@ static void process_cmd(char *cmd, Env_t *env) {
     if (errno != 0) {
         free_token_list(tok_l);
         free_expr_tree(tree);
-        return;
+        return NULL;
     }
     
     eval(&tree, env);
@@ -95,16 +140,13 @@ static void process_cmd(char *cmd, Env_t *env) {
     if (errno != 0) {
         free_token_list(tok_l);
         free_expr_tree(tree);
-        return;
+        return NULL;
     }
 
-    str = eval_result_to_str(tree);
+    result = eval_result_to_str(tree);
 
-    if (strlen(str) > 0) {
-        printf("%s\n", str);
-    }
-
-    free(str);
     free_token_list(tok_l);
     free_expr_tree(tree);
+
+    return result;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -104,24 +104,26 @@ static char *aggregate_args(int argc, char **argv) {
 }
 
 static void process_file(FILE *file, Env_t *env) {
-    char line[BUF_SIZE] = {0}, *result = NULL;
+    char line[BUF_SIZE] = {0}, *result = NULL, *result_to_print = NULL;
 
     while(fgets(line, BUF_SIZE, file)) {
-        free(result);
-        line[strlen(line) - 1] = '\0';
-
-        if (strcmp(line, "") == 0) {
-            continue;
-        }
+        line[strlen(line) - 1] = '\0'; /* strip newline */
 
         result = process_input(line, env);
+
+        if (result != NULL && strcmp(result, "") != 0) {
+            free(result_to_print);
+            result_to_print = result;
+        } else {
+            free(result);
+        }
     }
     
-    if (result != NULL) {
-        printf("%s\n", result);
+    if (result_to_print != NULL) {
+        printf("%s\n", result_to_print);
     }
 
-    free(result);
+    free(result_to_print);
     fclose(file);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,8 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 #include "lexer.h"
 #include "parser.h"
 #include "eval.h"

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,40 @@ int main(int argc, char **argv) {
     return 0;
 }
 
+static int is_empty(const char *str) {
+    int i;
+
+    for (i = 0; i < strlen(str); i++) {
+        if (str[i] != ' ' && str[i] != '\t' && str[i] != '\n') {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static void repl_loop(Env_t *env) {
+    char *line, *result;
+
+    while ((line = readline(PROMPT))) {
+        if (strcmp(line, "exit") == 0 || strcmp(line, "quit") == 0) {
+            break;
+        }
+
+        result = process_input(line, env);
+
+        if (result != NULL && strcmp(result, "") != 0) {
+            printf("%s\n", result);
+        }
+
+        if (!is_empty(line)) {
+            add_history(line);
+        }
+
+        free(result);
+    }
+}
+
 static char *aggregate_args(int argc, char **argv) {
     int i, expr_length = 0;
     char *expr;
@@ -89,29 +123,6 @@ static void process_file(FILE *file, Env_t *env) {
 
     free(result);
     fclose(file);
-}
-
-static void repl_loop(Env_t *env) {
-    char *line, *result;
-
-    while ((line = readline(PROMPT))) {
-        if (strcmp(line, "") == 0) {
-            continue;
-        }
-
-        if (strcmp(line, "exit") == 0 || strcmp(line, "quit") == 0) {
-            break;
-        }
-
-        result = process_input(line, env);
-
-        if (result != NULL) {
-            printf("%s\n", result);
-        }
-
-        add_history(line);
-        free(result);
-    }
 }
 
 static char *process_input(char *input, Env_t *env) {

--- a/src/main.c
+++ b/src/main.c
@@ -94,6 +94,7 @@ static char *aggregate_args(int argc, char **argv) {
     }
 
     expr = malloc(expr_length + 1);
+    expr[0] = '\0';
 
     for (i = 1; i < argc; i++) {
         strcat(expr, argv[i]);

--- a/src/parser.c
+++ b/src/parser.c
@@ -58,6 +58,10 @@ static ExprTree *parse_input(TokenList *tok_l, TokenList **out_tl) {
     ExprTree *expr = NULL;
     TokenList *t = tok_l;
 
+    if (tok_l == NULL) {
+        return NULL;
+    }
+
     if (tok_l->token != TOK_COMMENT) {
         expr = parse_expr(tok_l, &t);
     } else {
@@ -80,12 +84,6 @@ static ExprTree *parse_expr(TokenList *tok_l, TokenList **out_tl) {
     TokenList *t;
 
     if (errno != 0) {
-        return NULL;
-    }
-
-    if (tok_l == NULL) {
-        errno = EINVAL;
-        warn("parser: Empty input");
         return NULL;
     }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -112,7 +112,7 @@ static ExprTree *parse_expr(TokenList *tok_l, TokenList **out_tl) {
  * FunctionExpr -> fn ID(ParamExpr) = AdditiveExpr \n
  */
 static ExprTree *parse_function_expr(TokenList *tok_l, TokenList **out_tl) {
-    TokenList *t, *t2, *t3, *t4, *t5, *t6, *t7, *t8;
+    TokenList *t, *t2, *t3, *t4, *t5, *t6, *t7;
     ExprTree *fun_expr, *param_expr, *body_expr;
     char *id, *id_cpy;
 
@@ -136,15 +136,13 @@ static ExprTree *parse_function_expr(TokenList *tok_l, TokenList **out_tl) {
 
     body_expr = parse_additive_expr(t6, &t7);
 
-    t8 = match_token(t7, TOK_ENDLN);
-
     fun_expr = malloc(sizeof(ExprTree));
     fun_expr->expr = Fun;
     fun_expr->value.id = id_cpy;
     fun_expr->left = param_expr;
     fun_expr->right = body_expr;
 
-    *out_tl = t8;
+    *out_tl = t7;
     return fun_expr;
 }
 
@@ -184,7 +182,7 @@ static ExprTree *parse_parameter_expr(TokenList *tok_l, TokenList **out_tl) {
  * AssignmentExpr -> ID = AdditiveExpr \n
  */
 static ExprTree *parse_assignment_expr(TokenList *tok_l, TokenList **out_tl) {
-    TokenList *t, *t2, *t3, *t4;
+    TokenList *t, *t2, *t3;
     ExprTree *assign_expr, *id_expr, *val_expr;
 
     if (errno != 0) {
@@ -194,14 +192,13 @@ static ExprTree *parse_assignment_expr(TokenList *tok_l, TokenList **out_tl) {
     id_expr = parse_primary_expr(tok_l, &t);
     t2 = match_token(t, TOK_EQUAL);
     val_expr = parse_additive_expr(t2, &t3);
-    t4 = match_token(t3, TOK_ENDLN);
 
     assign_expr = malloc(sizeof(ExprTree));
     assign_expr->expr = Assign;
     assign_expr->left = id_expr;
     assign_expr->right = val_expr;
 
-    *out_tl = t4;
+    *out_tl = t3;
     return assign_expr;
 }
 

--- a/tests/eval_tests.c
+++ b/tests/eval_tests.c
@@ -124,7 +124,9 @@ int main(int argc, char **argv) {
     printf(C_SUITE_NAME("eval tests") "\n");
     printf("|\n");
 
+    compile_regexs();
     num_passed = run_all_tests(tests, num_tests);
+    free_regexs();
     suite_result = num_passed == num_tests ? SUCCESS : FAILURE;
 
     printf("|\n| Ran (%d/%d) tests successfully\n", num_passed, num_tests);
@@ -449,11 +451,11 @@ static Input *create_input8() {
 
 static Input *create_input9() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("f(42, 0.01)\n"), *tok_l_2;
+    TokenList *tok_l = tokenize("f(42, 0.01)"), *tok_l_2;
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
-    tok_l_2 = tokenize("fn f(x, y) = x * y - 0.123456\n");
+    tok_l_2 = tokenize("fn f(x, y) = x * y - 0.123456");
     t_extend_env(env, "f", parse(tok_l_2));
 
     input->tree = tree;
@@ -467,7 +469,7 @@ static Input *create_input9() {
 
 static Input *create_input10() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("num = num + 1\n");
+    TokenList *tok_l = tokenize("num = num + 1");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
@@ -483,7 +485,7 @@ static Input *create_input10() {
 
 static Input *create_input11() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("fn area(r) = 3.14 * r*r\n");
+    TokenList *tok_l = tokenize("fn area(r) = 3.14 * r*r");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
@@ -499,7 +501,7 @@ static Input *create_input11() {
 
 static Input *create_input12() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("4 + 3 * (2 - 3)\n");
+    TokenList *tok_l = tokenize("4 + 3 * (2 - 3)");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
@@ -513,7 +515,7 @@ static Input *create_input12() {
 
 static Input *create_input13() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("var = 2*(var+1)/12\n");
+    TokenList *tok_l = tokenize("var = 2*(var+1)/12");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
@@ -529,7 +531,7 @@ static Input *create_input13() {
 
 static Input *create_input14() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("2^3\n");
+    TokenList *tok_l = tokenize("2^3");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 
@@ -543,11 +545,11 @@ static Input *create_input14() {
 
 static Input *create_input15() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("(4*2)^(f(23 - 2)^3)\n"), *tok_l_2;
+    TokenList *tok_l = tokenize("(4*2)^(f(23 - 2)^3)"), *tok_l_2;
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
     
-    tok_l_2 = tokenize("fn f(x) = x - 21\n");
+    tok_l_2 = tokenize("fn f(x) = x - 21");
     t_extend_env(env, "f", parse(tok_l_2));
 
     input->tree = tree;
@@ -561,7 +563,7 @@ static Input *create_input15() {
 
 static Input *create_input16() {
     Input *input = malloc(sizeof(Input));
-    TokenList *tok_l = tokenize("64^0.5\n");
+    TokenList *tok_l = tokenize("64^0.5");
     ExprTree *tree = parse(tok_l);
     Env_t *env = init_env();
 

--- a/tests/lexer_tests.c
+++ b/tests/lexer_tests.c
@@ -16,18 +16,18 @@ static int run_test(Test *test);
 int main(int argc, char **argv) {
     Test tests[] = {
         {"empty_input", "", "[]"},
-        {"comment", "# a comment\n", "[TOK_COMMENT, TOK_ENDLN]"},
-        {"math + comment", "1 + 1 # a comment\n", "[TOK_INT 1, TOK_ADD, TOK_INT 1, TOK_COMMENT, TOK_ENDLN]"},
+        {"comment", "# a comment", "[TOK_COMMENT]"},
+        {"math + comment", "1 + 1 # a comment", "[TOK_INT 1, TOK_ADD, TOK_INT 1, TOK_COMMENT]"},
         {"arithmetic_toks", "+ - /*", "[TOK_ADD, TOK_SUB, TOK_DIV, TOK_MULT]"},
-        {"other_toks", "().=^\n", "[TOK_LPAREN, TOK_RPAREN, TOK_DOT, TOK_EQUAL, TOK_EXP, TOK_ENDLN]"},
+        {"other_toks", "().=^", "[TOK_LPAREN, TOK_RPAREN, TOK_DOT, TOK_EQUAL, TOK_EXP]"},
         {"fn_tok", "fn", "[TOK_FUN]"},
         {"basic_addition", "1 + 3", "[TOK_INT 1, TOK_ADD, TOK_INT 3]"},
         {"float + int + float", "2.20 + 5+5.", "[TOK_FLOAT 2.200000, TOK_ADD, TOK_INT 5, TOK_ADD, TOK_FLOAT 5.000000]"},
         {"big ints", "232342 4444", "[TOK_INT 232342, TOK_INT 4444]"},
         {"negative nums", "-23 - -33.4563", "[TOK_INT -23, TOK_SUB, TOK_FLOAT -33.456300]"},
         {"ids", "id1 snake_case CamelCase", "[TOK_ID id1, TOK_ID snake_case, TOK_ID CamelCase]"},
-        {"real use", "R = 500\nR*5", "[TOK_ID R, TOK_EQUAL, TOK_INT 500, TOK_ENDLN, TOK_ID R, TOK_MULT, TOK_INT 5]"},
-        {"all whitespace", "      \t\t \n \t\t\t  ", "[TOK_ENDLN]"},
+        {"real use", "R = 500R*5", "[TOK_ID R, TOK_EQUAL, TOK_INT 500, TOK_ID R, TOK_MULT, TOK_INT 5]"},
+        {"all whitespace", "      \t\t  \t\t\t  ", "[]"},
         {"comma", ",,,", "[TOK_COMMA, TOK_COMMA, TOK_COMMA]"},
         {"function", "fn f(a, b) = a + b", 
          "[TOK_FUN, TOK_ID f, TOK_LPAREN, TOK_ID a, TOK_COMMA, TOK_ID b, TOK_RPAREN, TOK_EQUAL, TOK_ID a, TOK_ADD, TOK_ID b]"}
@@ -45,6 +45,8 @@ int main(int argc, char **argv) {
 
     printf(C_SUITE_NAME("lexer tests") "\n");
     printf("|\n");
+
+    compile_regexs();
     
     for (i = 0; i < num_tests; i++) {
         Test *t = &(tests[i]);
@@ -68,6 +70,8 @@ int main(int argc, char **argv) {
             printf(SEP);
         }
     }
+
+    free_regexs();
 
     printf("|\n| Ran (%d/%d) tests successfully\n", num_passed, num_tests);
     printf("| Test suite %s\n", num_passed == num_tests ? PASSED : FAILED);

--- a/tests/parser_tests.c
+++ b/tests/parser_tests.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
         "(Add(Int 1)(Int 1))"
     };
     int num_tests = sizeof(t_names) / sizeof(char *), i, num_passed = 0;
-    TokenList **inputs = create_inputs(num_tests);
+    TokenList **inputs;
 
     if (argc == 2 && (strcmp(argv[1], "-v") == 0
                    || strcmp(argv[1], "--verbose") == 0)) {
@@ -68,6 +68,10 @@ int main(int argc, char **argv) {
     
     printf(C_SUITE_NAME("parser tests") "\n");
     printf("|\n");
+
+    compile_regexs();
+    inputs = create_inputs(num_tests);
+    free_regexs();
 
     for (i = 0; i < num_tests; i++) {
         Test t;
@@ -179,7 +183,6 @@ static TokenList **create_inputs(int num_tests) {
     t0 = append_token(NULL, TOK_INT, 1, 0, NULL);
     append_token(t0, TOK_ADD, 0, 0, NULL);
     append_token(t0, TOK_INT, 2, 0, NULL);
-    append_token(t0, TOK_ENDLN, 0, 0, NULL);
     inputs[0] = t0;
 
     t1 = append_token(NULL, TOK_INT, 44, 0, NULL);
@@ -187,7 +190,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t1, TOK_INT, 21, 0, NULL);
     append_token(t1, TOK_ADD, 0, 0, NULL);
     append_token(t1, TOK_FLOAT, 0, 2.2, NULL);
-    append_token(t1, TOK_ENDLN, 0, 0, NULL);
     inputs[1] = t1;
 
     t2 = append_token(NULL, TOK_FLOAT, 0, 2., NULL);
@@ -197,7 +199,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t2, TOK_INT, 12, 0, NULL);
     append_token(t2, TOK_ADD, 0, 0, NULL);
     append_token(t2, TOK_INT, 5, 0, NULL);
-    append_token(t2, TOK_ENDLN, 0, 0, NULL);
     inputs[2] = t2;
 
     t3 = append_token(NULL, TOK_INT, 1, 0, NULL);
@@ -209,7 +210,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t3, TOK_INT, 4, 0, NULL);
     append_token(t3, TOK_SUB, 0, 0, NULL);
     append_token(t3, TOK_INT, 5, 0, NULL);
-    append_token(t3, TOK_ENDLN, 0, 0, NULL);
     inputs[3] = t3;
 
     t4 = append_token(NULL, TOK_INT, 1, 0, NULL);
@@ -221,7 +221,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t4, TOK_INT, 4, 0, NULL);
     append_token(t4, TOK_DIV, 0, 0, NULL);
     append_token(t4, TOK_INT, 5, 0, NULL);
-    append_token(t4, TOK_ENDLN, 0, 0, NULL);
     inputs[4] = t4;
 
     {
@@ -231,7 +230,6 @@ static TokenList **create_inputs(int num_tests) {
     t5 = append_token(NULL, TOK_ID, 0, 0, id);
     append_token(t5, TOK_EQUAL, 0, 0, NULL);
     append_token(t5, TOK_INT, 500, 0, NULL);
-    append_token(t5, TOK_ENDLN, 0, 0, NULL);
     inputs[5] = t5;
     }
 
@@ -248,7 +246,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t6, TOK_INT, 2, 0, NULL);
     append_token(t6, TOK_MULT, 0, 0, NULL);
     append_token(t6, TOK_ID, 0, 0, id2);
-    append_token(t6, TOK_ENDLN, 0, 0, NULL);
     inputs[6] = t6;
     }
 
@@ -277,7 +274,6 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t7, TOK_ID, 0, 0, id5);
     append_token(t7, TOK_SUB, 0, 0, NULL);
     append_token(t7, TOK_FLOAT, 0, 0.123456, NULL);
-    append_token(t7, TOK_ENDLN, 0, 0, NULL);
     inputs[7] = t7;
     }
 
@@ -291,18 +287,17 @@ static TokenList **create_inputs(int num_tests) {
     append_token(t8, TOK_COMMA, 0, 0, NULL);
     append_token(t8, TOK_FLOAT, 0, 0.01, NULL);
     append_token(t8, TOK_RPAREN, 0, 0, NULL);
-    append_token(t8, TOK_ENDLN, 0, 0, NULL);
     inputs[8] = t8;
     }
 
-    inputs[9] = tokenize("fn area(r) = 3.14 * r*r\n");
-    inputs[10] = tokenize("4 + 3 * (2 - 3)\n");
-    inputs[11] = tokenize("var=2*(var+1)/12\n");
-    inputs[12] = tokenize("my_fun(0,arg, a, b, 2.0)*3\n");
-    inputs[13] = tokenize("2^3\n");
-    inputs[14] = tokenize("(4*2)^(f(23 - 2)^3)\n");
-    inputs[15] = tokenize("# a comment\n");
-    inputs[16] = tokenize("1 + 1 # a comment\n");
+    inputs[9] = tokenize("fn area(r) = 3.14 * r*r");
+    inputs[10] = tokenize("4 + 3 * (2 - 3)");
+    inputs[11] = tokenize("var=2*(var+1)/12");
+    inputs[12] = tokenize("my_fun(0,arg, a, b, 2.0)*3");
+    inputs[13] = tokenize("2^3");
+    inputs[14] = tokenize("(4*2)^(f(23 - 2)^3)");
+    inputs[15] = tokenize("# a comment");
+    inputs[16] = tokenize("1 + 1 # a comment");
 
     return inputs;
 }


### PR DESCRIPTION
Addresses #15 

Added support for readline to get extra keybindings and history for the repl/shell.
Also changed invocation behavior so now the following is true:

- 0 additional arguments will start the repl
- 1 or more additional arguments will evaluate the given arguments as an expression
- Input redirection will evaluate line by line, only printing the last non-empty line (comments by themselves are considered empty lines)